### PR TITLE
Implement OpenAI analysis settings and UI refinements

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import DiaryList from '../views/DiaryList.vue';
 import DiaryForm from '../views/DiaryForm.vue';
 import DiaryDetail from '../views/DiaryDetail.vue';
 import DiaryAnalysis from '../views/DiaryAnalysis.vue';
+import Settings from '../views/Settings.vue';
 
 const routes = [
   {
@@ -33,6 +34,11 @@ const routes = [
     name: 'diaryAnalysis',
     component: DiaryAnalysis,
     props: true,
+  },
+  {
+    path: '/settings',
+    name: 'settings',
+    component: Settings,
   },
   {
     path: '/:pathMatch(.*)*',

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -1,0 +1,67 @@
+import { computed, ref } from 'vue';
+
+const STORAGE_KEY = 'emotion-diary-settings';
+
+function loadSettings() {
+  if (typeof window === 'undefined') {
+    return { apiKey: '' };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { apiKey: '' };
+    }
+
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { apiKey: '' };
+    }
+
+    return {
+      apiKey: typeof parsed.apiKey === 'string' ? parsed.apiKey : '',
+    };
+  } catch (error) {
+    console.warn('Failed to read settings from storage:', error);
+    return { apiKey: '' };
+  }
+}
+
+const settings = ref(loadSettings());
+
+function persist() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings.value));
+}
+
+export function useSettingsStore() {
+  const apiKey = computed(() => settings.value.apiKey || '');
+
+  const setApiKey = value => {
+    settings.value = {
+      ...settings.value,
+      apiKey: (value || '').trim(),
+    };
+    persist();
+  };
+
+  const clearApiKey = () => {
+    if (!settings.value.apiKey) {
+      return;
+    }
+    settings.value = {
+      ...settings.value,
+      apiKey: '',
+    };
+    persist();
+  };
+
+  return {
+    apiKey,
+    setApiKey,
+    clearApiKey,
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -64,10 +64,16 @@ button {
 }
 
 .home-hero {
-  text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.home-hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .home-hero h1 {
@@ -315,6 +321,53 @@ button {
   flex-direction: column;
   gap: 20px;
   box-shadow: 0 24px 60px rgba(31, 26, 23, 0.08);
+}
+
+.settings-card {
+  gap: 18px;
+  text-align: left;
+}
+
+.settings-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-intro h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #463c35;
+}
+
+.settings-intro p {
+  margin: 0;
+  color: #6e655f;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-hint {
+  margin: 0;
+  font-size: 13px;
+  color: #857b73;
+}
+
+.settings-hint a {
+  color: #b47b1b;
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .section-heading {
@@ -625,16 +678,31 @@ button {
 .analysis-layout {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  min-height: 520px;
+  gap: 16px;
+  min-height: 480px;
   flex: 1;
   position: relative;
+}
+
+.analysis-alert {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 16px;
+  font-size: 13px;
+  line-height: 1.5;
+  background: rgba(73, 63, 56, 0.08);
+  color: #5c524a;
+}
+
+.analysis-alert.error {
+  background: rgba(255, 117, 117, 0.18);
+  color: #b91c1c;
 }
 
 .message-list {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   flex: 1;
   overflow-y: auto;
   padding-right: 4px;
@@ -663,6 +731,11 @@ button {
   background: rgba(255, 240, 209, 0.7);
 }
 
+.message.pending .message-content {
+  font-style: italic;
+  color: #6e655f;
+}
+
 .message.user {
   grid-template-columns: 1fr;
   justify-items: end;
@@ -683,16 +756,16 @@ button {
 
 .analysis-input {
   position: sticky;
-  bottom: 24px;
+  bottom: 12px;
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
-  padding: 16px 18px;
-  border-radius: 26px;
+  padding: 12px 16px;
+  border-radius: 20px;
   background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 28px 60px rgba(31, 26, 23, 0.18);
-  backdrop-filter: blur(16px);
+  box-shadow: 0 24px 48px rgba(31, 26, 23, 0.16);
+  backdrop-filter: blur(14px);
   z-index: 5;
   margin-top: auto;
 }

--- a/src/views/DiaryAnalysis.vue
+++ b/src/views/DiaryAnalysis.vue
@@ -16,15 +16,27 @@
       </section>
 
       <div v-else class="analysis-layout">
+        <p v-if="analysisError" class="analysis-alert error">{{ analysisError }}</p>
+
         <div ref="messageList" class="message-list">
+          <p v-if="!messages.length && !isLoading && !analysisError" class="muted-text">
+            Your insights will appear here once the analysis is ready.
+          </p>
+
           <div
             v-for="message in messages"
             :key="message.id"
             class="message"
             :class="message.role"
+            :data-message-id="message.id"
           >
             <div class="message-icon" v-if="message.role === 'assistant'">✨</div>
             <div class="message-content">{{ message.text }}</div>
+          </div>
+
+          <div v-if="isLoading" class="message assistant pending">
+            <div class="message-icon">✨</div>
+            <div class="message-content">Analyzing your entry…</div>
           </div>
         </div>
 
@@ -35,8 +47,9 @@
             v-model="question"
             type="text"
             placeholder="Ask a follow-up question..."
+            :disabled="isLoading"
           />
-          <button type="submit" class="send-button" :disabled="!question.trim()">
+          <button type="submit" class="send-button" :disabled="!question.trim() || isLoading">
             <span aria-hidden="true">➤</span>
             <span class="sr-only">Send</span>
           </button>
@@ -50,6 +63,7 @@
 import { computed, nextTick, ref, watch } from 'vue';
 import { RouterLink, useRouter } from 'vue-router';
 import { useDiaryStore } from '../stores/diaryStore.js';
+import { useSettingsStore } from '../stores/settingsStore.js';
 import { getMoodMeta } from '../utils/moods.js';
 
 const props = defineProps({
@@ -61,94 +75,191 @@ const props = defineProps({
 
 const router = useRouter();
 const { getDiaryById } = useDiaryStore();
+const { apiKey } = useSettingsStore();
 
 const diary = computed(() => getDiaryById(props.id));
 const question = ref('');
 const messages = ref([]);
 const messageList = ref(null);
+const conversation = ref([]);
+const isLoading = ref(false);
+const analysisError = ref('');
+
+const SYSTEM_PROMPT = `You are a compassionate journaling coach. Offer warm, practical reflections in two or three short paragraphs. Reference the person's mood, feelings, thoughts, behaviours, and outcomes. Encourage gentle self-awareness and next steps without sounding clinical.`;
 
 function createMessageId() {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-function buildInsights(entry) {
-  if (!entry) {
-    return [];
-  }
-
-  const mood = getMoodMeta(entry.mood);
-  const feelings = entry.emotions || 'the feelings you experienced';
-  const thoughts = entry.thoughts || 'the thoughts you noted';
-  const behaviors = entry.behaviors || 'the actions you described';
-  const consequences = entry.consequences || 'the outcomes you mentioned';
-
-  return [
-    {
-      id: createMessageId(),
-      role: 'assistant',
-      text: `It seems ${entry.fact || 'this moment'} left you feeling ${feelings}. Your mood was noted as ${mood.label.toLowerCase()}, suggesting a strong emotional impact.`,
-    },
-    {
-      id: createMessageId(),
-      role: 'assistant',
-      text: `You described ${behaviors.toLowerCase()} and linked it with ${consequences.toLowerCase()}. How might these reactions have been shaped by ${thoughts.toLowerCase()}?`,
-    },
-    {
-      id: createMessageId(),
-      role: 'assistant',
-      text: `Consider one small way to respond differently if a similar situation happens again. What support or self-talk could help you move from feeling ${mood.label.toLowerCase()} toward a more balanced state?`,
-    },
-  ];
-}
-
 watch(
   diary,
   value => {
-    messages.value = buildInsights(value);
-    scrollToBottom();
+    messages.value = [];
+    conversation.value = [];
+    analysisError.value = '';
+    question.value = '';
+
+    if (value) {
+      runInitialAnalysis();
+    }
   },
   { immediate: true },
 );
 
-function scrollToBottom() {
+watch(apiKey, () => {
+  if (!diary.value) {
+    return;
+  }
+
+  if (!apiKey.value) {
+    analysisError.value = 'Add your OpenAI API key in Settings to enable AI analysis.';
+    return;
+  }
+
+  if (!messages.value.length && !isLoading.value) {
+    analysisError.value = '';
+    runInitialAnalysis();
+  }
+});
+
+function buildInitialPrompt(entry) {
+  const mood = getMoodMeta(entry.mood);
+  const feelings = entry.emotions || 'Not specified';
+  const thoughts = entry.thoughts || 'Not specified';
+  const behaviors = entry.behaviors || 'Not specified';
+  const consequences = entry.consequences || 'Not specified';
+
+  return `Diary entry details:\nMood: ${mood.label} (${entry.mood})\nEvent: ${entry.fact || 'Not specified'}\nFeelings: ${feelings}\nPsychological notes: ${(entry.psychological || []).join(', ') || 'Not specified'}\nPhysiological notes: ${(entry.physiological || []).join(', ') || 'Not specified'}\nThoughts: ${thoughts}\nBehaviors: ${behaviors}\nConsequences: ${consequences}\n\nPlease provide a caring reflection that helps the writer process this experience.`;
+}
+
+async function runInitialAnalysis() {
+  if (!diary.value) {
+    return;
+  }
+
+  if (!apiKey.value) {
+    analysisError.value = 'Add your OpenAI API key in Settings to enable AI analysis.';
+    return;
+  }
+
+  isLoading.value = true;
+  conversation.value = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: buildInitialPrompt(diary.value) },
+  ];
+
+  try {
+    const reply = await requestOpenAI(conversation.value);
+    const assistantMessage = { id: createMessageId(), role: 'assistant', text: reply };
+    messages.value.push(assistantMessage);
+    conversation.value.push({ role: 'assistant', content: reply });
+    analysisError.value = '';
+    scrollToMessage(assistantMessage.id, 'end');
+  } catch (error) {
+    analysisError.value = formatError(error);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+function scrollToMessage(targetId, position = 'end') {
   nextTick(() => {
-    if (messageList.value) {
-      messageList.value.scrollTop = messageList.value.scrollHeight;
+    const container = messageList.value;
+    if (!container) {
+      return;
+    }
+
+    if (targetId) {
+      const element = container.querySelector(`[data-message-id="${targetId}"]`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: position, inline: 'nearest' });
+        return;
+      }
+    }
+
+    if (position === 'start') {
+      container.scrollTop = 0;
+    } else {
+      container.scrollTop = container.scrollHeight;
     }
   });
 }
 
-function goBack() {
-  if (window.history.length > 1) {
-    router.back();
-  } else if (diary.value) {
-    router.push({ name: 'diaryDetail', params: { id: diary.value.id } });
-  } else {
-    router.push({ name: 'home' });
+function formatError(error) {
+  if (error instanceof Error) {
+    return `AI analysis failed: ${error.message}`;
   }
+  return 'AI analysis failed. Please try again later.';
 }
 
-function buildFollowUpResponse(query, entry) {
-  const mood = getMoodMeta(entry.mood);
-  return {
-    id: createMessageId(),
-    role: 'assistant',
-    text: `Thanks for sharing more. When you think about "${query}", notice how it relates to feeling ${mood.label.toLowerCase()}. What gentle step could you take to care for yourself before, during, or after a similar moment?`,
-  };
+async function requestOpenAI(payload) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey.value}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: payload,
+      temperature: 0.7,
+    }),
+  });
+
+  let data = null;
+  try {
+    data = await response.json();
+  } catch (error) {
+    data = null;
+  }
+
+  if (!response.ok) {
+    const message = data?.error?.message || response.statusText || 'Unable to reach OpenAI.';
+    throw new Error(message);
+  }
+
+  const content = data?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error('The AI response was empty.');
+  }
+
+  return content.trim();
 }
 
-function submitQuestion() {
+function goBack() {
+  router.push({ name: 'diaryDetail', params: { id: props.id } });
+}
+
+async function submitQuestion() {
   if (!question.value.trim() || !diary.value) {
     return;
   }
 
   const content = question.value.trim();
-  messages.value = [
-    ...messages.value,
-    { id: createMessageId(), role: 'user', text: content },
-    buildFollowUpResponse(content, diary.value),
-  ];
+  const userMessage = { id: createMessageId(), role: 'user', text: content };
+  messages.value.push(userMessage);
+  conversation.value.push({ role: 'user', content });
   question.value = '';
-  scrollToBottom();
+  scrollToMessage(userMessage.id, 'start');
+
+  if (!apiKey.value) {
+    analysisError.value = 'Add your OpenAI API key in Settings to enable AI analysis.';
+    return;
+  }
+
+  isLoading.value = true;
+
+  try {
+    const reply = await requestOpenAI(conversation.value);
+    const assistantMessage = { id: createMessageId(), role: 'assistant', text: reply };
+    messages.value.push(assistantMessage);
+    conversation.value.push({ role: 'assistant', content: reply });
+    analysisError.value = '';
+    scrollToMessage(assistantMessage.id, 'end');
+  } catch (error) {
+    analysisError.value = formatError(error);
+  } finally {
+    isLoading.value = false;
+  }
 }
 </script>

--- a/src/views/DiaryDetail.vue
+++ b/src/views/DiaryDetail.vue
@@ -128,13 +128,17 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 const emotionTags = computed(() => {
-  if (!diary.value || !diary.value.emotions) {
+  const entry = diary.value;
+  if (!entry || !entry.emotions) {
     return [];
   }
-  return diary.value.emotions
+
+  const presetTags = new Set([...(entry.psychological || []), ...(entry.physiological || [])]);
+
+  return entry.emotions
     .split(',')
     .map(tag => tag.trim())
-    .filter(Boolean);
+    .filter(tag => tag && !presetTags.has(tag));
 });
 
 function formatFullDate(value) {
@@ -146,11 +150,7 @@ function formatFullDate(value) {
 }
 
 function goBack() {
-  if (window.history.length > 1) {
-    router.back();
-  } else {
-    router.push({ name: 'home' });
-  }
+  router.push({ name: 'home' });
 }
 
 function requestDelete() {

--- a/src/views/DiaryForm.vue
+++ b/src/views/DiaryForm.vue
@@ -53,7 +53,12 @@
 
         <label class="form-field">
           <span>Fact</span>
-          <input v-model.trim="form.fact" type="text" placeholder="e.g., I had an argument with my partner." required />
+          <textarea
+            v-model.trim="form.fact"
+            rows="3"
+            placeholder="e.g., I had an argument with my partner."
+            required
+          ></textarea>
         </label>
 
         <label class="form-field">

--- a/src/views/DiaryList.vue
+++ b/src/views/DiaryList.vue
@@ -2,7 +2,12 @@
   <div class="page home-page">
     <div class="page-inner">
       <header class="home-hero">
-        <h1>Mood Log</h1>
+        <div class="home-hero-top">
+          <h1>Mood Log</h1>
+          <RouterLink to="/settings" class="icon-button" aria-label="Open settings">
+            <span aria-hidden="true">⚙️</span>
+          </RouterLink>
+        </div>
         <p>Track how you feel and notice patterns over time.</p>
       </header>
 
@@ -89,10 +94,12 @@ function extractTags(entry) {
     return [];
   }
 
+  const presetTags = new Set([...(entry.psychological || []), ...(entry.physiological || [])]);
+
   return entry.emotions
     .split(',')
     .map(tag => tag.trim())
-    .filter(Boolean)
+    .filter(tag => tag && !presetTags.has(tag))
     .slice(0, 3);
 }
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="page settings-page">
+    <div class="page-inner">
+      <header class="page-header">
+        <button type="button" class="icon-button" @click="goBack">
+          <span aria-hidden="true">←</span>
+          <span class="sr-only">Back</span>
+        </button>
+        <h1>Settings</h1>
+        <div class="header-spacer" aria-hidden="true"></div>
+      </header>
+
+      <section class="form-card settings-card">
+        <div class="settings-intro">
+          <h2>OpenAI API Key</h2>
+          <p>
+            Provide your personal OpenAI API key to enable real AI-powered analysis. Your key is only stored locally in this
+            browser.
+          </p>
+        </div>
+
+        <form class="settings-form" @submit.prevent="saveKey">
+          <label class="form-field">
+            <span>API Key</span>
+            <input
+              v-model.trim="localKey"
+              type="password"
+              inputmode="text"
+              autocomplete="off"
+              placeholder="sk-..."
+              required
+            />
+          </label>
+
+          <p class="settings-hint">
+            You can create or manage keys from your
+            <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">OpenAI dashboard</a>.
+          </p>
+
+          <div class="settings-actions">
+            <button type="submit" class="primary-button">Save Key</button>
+            <button type="button" class="primary-button ghost" @click="clearKey">Remove Key</button>
+          </div>
+        </form>
+
+        <p v-if="feedback" class="form-feedback">{{ feedback }}</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useSettingsStore } from '../stores/settingsStore.js';
+
+const router = useRouter();
+const { apiKey, setApiKey, clearApiKey } = useSettingsStore();
+
+const localKey = ref('');
+const feedback = ref('');
+
+watch(
+  apiKey,
+  value => {
+    localKey.value = value;
+  },
+  { immediate: true },
+);
+
+function goBack() {
+  router.push({ name: 'home' });
+}
+
+function saveKey() {
+  if (!localKey.value) {
+    feedback.value = 'Please paste a valid API key to continue.';
+    return;
+  }
+
+  setApiKey(localKey.value);
+  feedback.value = 'API key saved. You can now use AI analysis.';
+}
+
+function clearKey() {
+  clearApiKey();
+  localKey.value = '';
+  feedback.value = 'API key removed.';
+}
+</script>


### PR DESCRIPTION
## Summary
- add an OpenAI API key settings page and store, and expose the entry point from the home view
- integrate real OpenAI chat completions into the AI analysis view with better messaging, scrolling, and styling
- align fact input sizing, hide preset feeling tags from summaries, and standardize back navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d544286ad48327b469df9b5b6ef9f0