### PR TITLE
Improve diary list truncation and AI markdown rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "emotion-diary",
       "version": "0.0.0",
       "dependencies": {
+        "marked": "^12.0.2",
         "vue": "^3.5.21",
         "vue-router": "^4.5.1"
       },
@@ -1061,6 +1062,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "marked": "^12.0.2",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1"
   },

--- a/src/style.css
+++ b/src/style.css
@@ -214,6 +214,12 @@ button {
   font-size: 17px;
   font-weight: 600;
   color: #2b2521;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 .entry-tags {
@@ -762,6 +768,35 @@ button {
   font-size: 14px;
   line-height: 1.6;
   background: rgba(73, 63, 56, 0.08);
+}
+
+.message-content--plain {
+  white-space: pre-wrap;
+}
+
+.message-content :where(p, ul, ol) {
+  margin: 0;
+}
+
+.message-content :where(p, ul, ol) + :where(p, ul, ol) {
+  margin-top: 8px;
+}
+
+.message-content ul,
+.message-content ol {
+  padding-left: 20px;
+}
+
+.message-content li + li {
+  margin-top: 4px;
+}
+
+.message-content strong {
+  font-weight: 600;
+}
+
+.message-content em {
+  font-style: italic;
 }
 
 .analysis-input {


### PR DESCRIPTION
## Summary
- clamp diary list fact titles to two lines with an ellipsis to keep cards concise
- render assistant responses with Markdown formatting and safe HTML escaping for clearer AI analysis
- enhance message styling to support paragraphs and lists while preserving user-entered line breaks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54e249cbc83279ecc6ab7882ed806