### PR TITLE
Remove empty mood placeholders from calendar

### DIFF
--- a/src/views/TrendInsights.vue
+++ b/src/views/TrendInsights.vue
@@ -65,9 +65,6 @@
                 >
                   {{ item.icon }}
                 </span>
-                <span v-if="!day.moodStack.length" class="mood-stack-item mood-stack-item--empty" aria-hidden="true">
-                  ·
-                </span>
               </div>
               <div class="day-number">{{ day.dayNumber }}</div>
             </div>
@@ -101,9 +98,6 @@
                     aria-hidden="true"
                   >
                     {{ item.icon }}
-                  </span>
-                  <span v-if="!day.moodStack.length" class="mood-stack-item mood-stack-item--empty" aria-hidden="true">
-                    ·
                   </span>
                 </div>
               </div>
@@ -884,11 +878,6 @@ function goBack() {
   box-shadow: 0 14px 24px rgba(31, 26, 23, 0.08);
   border: 1px solid rgba(31, 26, 23, 0.06);
   transition: transform 0.2s ease;
-}
-
-.mood-stack-item--empty {
-  background: rgba(31, 26, 23, 0.08);
-  color: #71665d;
 }
 
 .day-number {


### PR DESCRIPTION
## Summary
- stop rendering placeholder mood markers on days without diary entries in the weekly and monthly calendars
- remove the unused styles related to the empty mood placeholder state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d61420d04883279b11fed1ba9bec46