### PR TITLE
Adjust trend insights layout and navigation

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -40,6 +40,7 @@ const routes = [
     path: '/insights',
     name: 'insights',
     component: () => import('../views/TrendInsights.vue'),
+    meta: { showBottomNav: true },
   },
   {
     path: '/settings',

--- a/src/style.css
+++ b/src/style.css
@@ -933,7 +933,7 @@ button {
   padding: 8px 12px;
   border-radius: 12px;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
   color: inherit;
   transition: background 0.2s ease, color 0.2s ease;
 }
@@ -950,9 +950,21 @@ button {
   line-height: 1.2;
 }
 
-.bottom-nav-item.active {
-  background: #1f1a17;
-  color: #ffffff;
+.bottom-nav-item:not(.bottom-nav-item--primary) {
+  background: transparent;
+}
+
+.bottom-nav-item:not(.bottom-nav-item--primary) .bottom-nav-label {
+  font-weight: 500;
+}
+
+.bottom-nav-item:not(.bottom-nav-item--primary).active {
+  background: transparent;
+  color: #2f261b;
+}
+
+.bottom-nav-item:not(.bottom-nav-item--primary).active .bottom-nav-label {
+  font-weight: 700;
 }
 
 .bottom-nav-item--primary {

--- a/src/views/TrendInsights.vue
+++ b/src/views/TrendInsights.vue
@@ -13,7 +13,6 @@
         <div class="insights-card-header">
           <div>
             <h2 id="calendar-title">心情日历</h2>
-            <p class="insights-card-subtitle">切换周/月视图，追踪每天的心情波动。</p>
           </div>
           <div class="view-toggle" role="tablist" aria-label="时间粒度切换">
             <button
@@ -763,12 +762,6 @@ function goBack() {
   gap: 16px;
 }
 
-.insights-card-subtitle {
-  margin: 4px 0 0;
-  color: #8a8078;
-  font-size: 14px;
-}
-
 .view-toggle {
   background: rgba(31, 26, 23, 0.06);
   border-radius: 999px;
@@ -903,10 +896,17 @@ function goBack() {
   padding: 10px 6px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   min-height: 64px;
+}
+
+.monthly-cell .day-number {
+  order: -1;
+}
+
+.monthly-cell .mood-stack {
+  order: 1;
 }
 
 .monthly-cell.is-outside {
@@ -994,7 +994,7 @@ function goBack() {
 
 @media (min-width: 768px) {
   .metrics-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- show the bottom navigation on the insights page and restyle the active tabs to use bold text instead of a dark background
- clean up the trend insights card copy and align the monthly calendar layout so the date sits above the emoji stack
- keep the key metrics stack vertical even on wide screens to match the latest design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d63677ff948327b78e0ab678383d47