### PR TITLE
Update diary time inputs and analysis layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -505,7 +505,8 @@ button {
 }
 
 .form-field input,
-.form-field textarea {
+.form-field textarea,
+.form-field select {
   width: 100%;
   padding: 12px 14px;
   border-radius: 16px;
@@ -518,10 +519,40 @@ button {
 }
 
 .form-field input:focus,
-.form-field textarea:focus {
+.form-field textarea:focus,
+.form-field select:focus {
   border-color: rgba(255, 184, 77, 0.9);
   box-shadow: 0 0 0 3px rgba(255, 184, 77, 0.25);
   background: #ffffff;
+}
+
+.form-field--datetime .datetime-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.form-field--datetime input[type='date'] {
+  flex: 1 1 180px;
+}
+
+.time-selectors {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.time-selectors select {
+  width: auto;
+  min-width: 72px;
+  padding-inline: 12px;
+  text-align: center;
+}
+
+.time-separator {
+  font-weight: 600;
+  color: #493f38;
 }
 
 .chip-group {
@@ -924,6 +955,25 @@ button {
   color: #4b433d;
   z-index: 10;
   backdrop-filter: blur(12px);
+}
+
+@media (min-width: 1024px) {
+  .bottom-nav {
+    bottom: calc(env(safe-area-inset-bottom, 0));
+    width: min(720px, 100%);
+    transform: translateX(-50%);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    box-shadow: 0 -10px 36px rgba(31, 26, 23, 0.12);
+    padding: 12px 24px calc(12px + env(safe-area-inset-bottom, 0));
+  }
+
+  .page {
+    padding-bottom: calc(200px + env(safe-area-inset-bottom, 0));
+  }
 }
 
 .bottom-nav-item {

--- a/src/views/DiaryList.vue
+++ b/src/views/DiaryList.vue
@@ -72,10 +72,8 @@ const confirmOpen = ref(false);
 const pendingDeleteId = ref('');
 
 const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
-  weekday: 'short',
   month: 'long',
   day: 'numeric',
-  year: 'numeric',
 });
 
 function formatDate(value) {

--- a/src/views/TrendInsights.vue
+++ b/src/views/TrendInsights.vue
@@ -64,12 +64,6 @@
                 <span class="daily-time">{{ item.timeLabel }}</span>
               </div>
             </div>
-            <div class="daily-ticks" aria-hidden="true">
-              <span v-for="tick in dailyTicks" :key="tick.value" class="daily-tick">
-                <span class="daily-tick-mark"></span>
-                <span class="daily-tick-label">{{ tick.label }}</span>
-              </span>
-            </div>
           </div>
           <p v-if="!dailyTimeline.length" class="daily-empty">今天还没有心情记录哦～</p>
         </div>
@@ -169,15 +163,6 @@
               :class="{ 'metric-value--muted': topEmotionState.muted }"
             >
               {{ topEmotionState.text }}
-            </p>
-          </article>
-          <article class="metric-card" role="listitem">
-            <h3 class="metric-title">高频触发场景</h3>
-            <p
-              class="metric-value"
-              :class="{ 'metric-value--muted': triggerAnalysisState.muted }"
-            >
-              {{ triggerAnalysisState.text }}
             </p>
           </article>
         </div>
@@ -459,15 +444,6 @@ const dailyEntries = computed(() => {
     .sort((a, b) => a.parsed - b.parsed);
 });
 
-const dailyTicks = computed(() => {
-  const marks = [0, 6, 12, 18, 24];
-  return marks.map(value => ({
-    value,
-    label: value === 24 ? '24:00' : `${String(value).padStart(2, '0')}:00`,
-    position: `${(value / 24) * 100}%`,
-  }));
-});
-
 const dailyTimeline = computed(() => {
   const slots = new Map();
   dailyEntries.value.forEach(({ entry, parsed }) => {
@@ -589,30 +565,10 @@ const topEmotionState = computed(() => {
   return { text: topEmotions.join(' / '), muted: false };
 });
 
-const aiTriggers = ref([]);
 const aiSummary = ref('');
 const aiLoading = ref(false);
 const aiError = ref('');
 let aiRequestId = 0;
-
-const triggerAnalysisState = computed(() => {
-  if (!rangeDiaries.value.length) {
-    return { text: '暂无数据', muted: true };
-  }
-  if (!hasApiKey.value) {
-    return { text: '需要配置 API Key', muted: true };
-  }
-  if (aiLoading.value) {
-    return { text: 'AI 分析中…', muted: true };
-  }
-  if (aiError.value) {
-    return { text: aiError.value, muted: true };
-  }
-  if (!aiTriggers.value.length) {
-    return { text: '暂无结果', muted: true };
-  }
-  return { text: aiTriggers.value.join('、'), muted: false };
-});
 
 const aiSummaryState = computed(() => {
   if (!rangeDiaries.value.length) {
@@ -639,7 +595,6 @@ watch(
   [() => rangeDiaries.value, () => hasApiKey.value, () => periodLabel.value],
   async ([entries, keyAvailable, label]) => {
     aiError.value = '';
-    aiTriggers.value = [];
     aiSummary.value = '';
 
     if (!entries.length || !keyAvailable) {
@@ -655,7 +610,6 @@ watch(
       if (requestId !== aiRequestId) {
         return;
       }
-      aiTriggers.value = insights.triggers;
       aiSummary.value = normalizeSummary(insights.summary);
       aiError.value = '';
     } catch (error) {
@@ -870,6 +824,8 @@ function goBack() {
   padding: 6px;
   display: inline-flex;
   gap: 6px;
+  align-items: center;
+  margin: 0 auto;
 }
 
 .insights-card-header {
@@ -913,7 +869,7 @@ function goBack() {
 
 .daily-axis {
   position: relative;
-  padding: 32px 0 24px;
+  padding: 32px 0 12px;
 }
 
 .daily-track {
@@ -959,41 +915,6 @@ function goBack() {
   padding: 4px 10px;
   box-shadow: 0 12px 24px rgba(31, 26, 23, 0.12);
   white-space: nowrap;
-}
-
-.daily-ticks {
-  margin-top: 20px;
-  display: flex;
-  justify-content: space-between;
-  color: #6f665e;
-  font-size: 12px;
-}
-
-.daily-tick {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  position: relative;
-  flex: 1;
-}
-
-.daily-tick:not(:last-child) .daily-tick-label {
-  align-self: flex-start;
-}
-
-.daily-tick:last-child .daily-tick-label {
-  align-self: flex-end;
-}
-
-.daily-tick-mark {
-  width: 1px;
-  height: 12px;
-  background: rgba(31, 26, 23, 0.14);
-}
-
-.daily-tick-label {
-  color: inherit;
 }
 
 .daily-empty {


### PR DESCRIPTION
## Summary
- add hour and minute selectors to the diary form with sensible defaults
- simplify the daily analysis timeline and remove the trigger metric card
- adjust diary list date formatting and pin the bottom nav on wide screens
- center the insights view mode toggle tabs in the calendar card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6410c21588327a46b4a2a9b890f9d